### PR TITLE
Update runtime to 6.10

### DIFF
--- a/org.kde.klevernotes.json
+++ b/org.kde.klevernotes.json
@@ -1,10 +1,10 @@
 {
     "id": "org.kde.klevernotes",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.9",
+    "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "base": "io.qt.qtwebengine.BaseApp",
-    "base-version": "6.9",
+    "base-version": "6.10",
     "command": "klevernotes",
     "finish-args": [
         "--device=dri",
@@ -20,27 +20,6 @@
         "/include"
     ],
     "modules": [
-        {
-            "name": "kirigami-addons",
-            "config-opts": [
-                "-DBUILD_TESTING=OFF",
-                "-DCMAKE_BUILD_TYPE=Release"
-            ],
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.11.0.tar.xz",
-                    "sha256": "6dcdfa324f710f00887e6321212fc8582a3c4712450d129d91435bb1edd8d523",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 242933,
-                        "stable-only": true,
-                        "url-template": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-$version.tar.xz"
-                    }
-                }
-            ]
-        },
         {
             "name": "klevernotes",
             "buildsystem": "cmake-ninja",


### PR DESCRIPTION
Also, drop the kirigami-addons module that provided by the runtime version 6.10.

Fixes: https://github.com/flathub/org.kde.klevernotes/issues/19